### PR TITLE
Disable middleware auth gate by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ expense-tracker/
 
 This project follows a spec-driven development approach. See the `.kiro/specs/expense-tracker/` directory for detailed requirements, design, and implementation tasks.
 
+### Temporarily disabling authentication
+
+The Edge middleware checks the Supabase session before allowing access to protected routes. To speed up development without going
+through the login flow, set the `NEXT_PUBLIC_ENABLE_AUTH` environment variable to `true` only when authentication should be
+enforced. When the variable is omitted (the default) the middleware will allow direct access to every page.
+
 ## License
 
 This project is private and not licensed for public use.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,6 +37,8 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
+  const isAuthEnabled = process.env.NEXT_PUBLIC_ENABLE_AUTH === 'true'
+
   const protectedPrefixes = [
     '/dashboard',
     '/expenses',
@@ -47,7 +49,10 @@ export async function middleware(request: NextRequest) {
   ]
 
   // Защищаем приватные страницы
-  if (protectedPrefixes.some(prefix => request.nextUrl.pathname.startsWith(prefix))) {
+  if (
+    isAuthEnabled &&
+    protectedPrefixes.some(prefix => request.nextUrl.pathname.startsWith(prefix))
+  ) {
     if (!user) {
       const url = request.nextUrl.clone()
       url.pathname = '/login'
@@ -56,8 +61,12 @@ export async function middleware(request: NextRequest) {
   }
 
   // Redirect authenticated users away from auth pages
-  if ((request.nextUrl.pathname.startsWith('/login') || 
-       request.nextUrl.pathname.startsWith('/signup')) && user) {
+  if (
+    isAuthEnabled &&
+    (request.nextUrl.pathname.startsWith('/login') ||
+      request.nextUrl.pathname.startsWith('/signup')) &&
+    user
+  ) {
     const url = request.nextUrl.clone()
     url.pathname = '/dashboard'
     return NextResponse.redirect(url)


### PR DESCRIPTION
## Summary
- guard the middleware redirects behind a NEXT_PUBLIC_ENABLE_AUTH flag so unauthenticated users can access all routes by default
- document how to re-enable the authentication check through the NEXT_PUBLIC_ENABLE_AUTH environment variable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0850d0fd883208a3ac53537a2fdb7